### PR TITLE
Update BatteryLightSettings.java

### DIFF
--- a/src/com/android/settings/kraken/BatteryLightSettings.java
+++ b/src/com/android/settings/kraken/BatteryLightSettings.java
@@ -1,4 +1,4 @@
-kraken/*
+/*
  * Copyright (C) 2022 The Kraken Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
fix class, interface, or enum expected derp?

packages/apps/Settings/src/com/android/settings/kraken/BatteryLightSettings.java:1: error: class, interface, or enum expected
kraken/*
^
